### PR TITLE
Removed: lazy loading of cover image

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,6 @@
           sizes="xl:85vw xxl:90vw"
           src="/img/index/portada.png"
           format="webp"
-          loading="lazy"
           alt="Livieres Guggiari - Portada"
         />
         <nav>
@@ -51,7 +50,6 @@
           src="/img/index/portada.png"
           sizes="xs:90vw sm:80vw md:90vw lg:85vw"
           format="webp"
-          loading="lazy"
           alt="Livieres Guggiari - Portada"
         />
       </div>


### PR DESCRIPTION
@moisesDev35 las imagenes que son directamente visibles al cargar la pagina no tienen que tener lazy loading: 
![image](https://github.com/estudioobliquo/livieresg.com.py/assets/58706604/00dd11dc-9249-4c03-8694-1a58f8f4138e)
